### PR TITLE
Add an editorconfig for C/C++ files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{c,h}{,pp}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Add .editorconfig configuration for C/C++.

https://editorconfig.org/ has details on the full format details. I didn't add anything for auxiliary file formats like CMakeLists.txt but we could.