### PR TITLE
Relax valgrind suppression, enable 24.04 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{matrix.os}}
     steps:
       - run: >

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -8,6 +8,4 @@
    fun:_dl_allocate_tls
    ...
    fun:pthread_create@@*
-   ...
-   fun:g_thread_pool_*
 }


### PR DESCRIPTION
It appears that the call stack related to the perceived memory leak related to stack allocation in threads has changed slightly in Ubuntu 24.04. This change relaxes that suppression slightly and enables 24.04 builds by default.

Independently, this suppression needs to be relaxed in the same way to be applicable to std::thread instances used in testing, for which the same perceived leak manifests.