### PR TITLE
Refactor Assuan code to make integration testing easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,17 +44,38 @@ set_target_properties(createrepo-cache PROPERTIES
   SOVERSION ${CRA_VERSION_MAJOR}
   VERSION ${CRA_VERSION})
 
-# Agent
+# Client/Server
 configure_file(
   "src/${PROJECT_NAME}/common.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/gen/${PROJECT_NAME}/common.h"
   @ONLY)
-add_executable(${PROJECT_NAME}
-  src/${PROJECT_NAME}/agent.c
+add_library(createrepo-agent-lib OBJECT
   src/${PROJECT_NAME}/client.c
   src/${PROJECT_NAME}/command.c
-  src/${PROJECT_NAME}/options.c)
-target_include_directories(${PROJECT_NAME} PRIVATE src "${CMAKE_CURRENT_BINARY_DIR}/gen")
+  src/${PROJECT_NAME}/options.c
+  src/${PROJECT_NAME}/server.c)
+target_include_directories(createrepo-agent-lib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/gen>)
+target_include_directories(createrepo-agent-lib SYSTEM PRIVATE
+  ${CREATEREPO_C_INCLUDE_DIRS})
+target_include_directories(createrepo-agent-lib SYSTEM PUBLIC
+  ${GLIB2_INCLUDE_DIRS}
+  ${GPG_ERROR_INCLUDE_DIRS}
+  ${LIBASSUAN_INCLUDE_DIRS})
+target_link_libraries(createrepo-agent-lib PRIVATE
+  createrepo-cache
+  ${CREATEREPO_C_LIBRARIES})
+target_link_libraries(createrepo-agent-lib PUBLIC
+  ${GLIB2_LIBRARIES}
+  ${GPG_ERROR_LIBRARIES}
+  ${LIBASSUAN_LIBRARIES})
+target_compile_definitions(createrepo-agent-lib PRIVATE
+  -DG_LOG_DOMAIN="CREATEREPO_AGENT")
+
+# Executable
+add_executable(${PROJECT_NAME}
+  src/${PROJECT_NAME}/agent.c)
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
   ${CREATEREPO_C_INCLUDE_DIRS}
   ${GLIB2_INCLUDE_DIRS}
@@ -62,14 +83,12 @@ target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
   ${GPGME_INCLUDE_DIRS}
   ${LIBASSUAN_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  createrepo-cache
+  createrepo-agent-lib
   ${CREATEREPO_C_LIBRARIES}
   ${GLIB2_LIBRARIES}
   ${GPG_ERROR_LIBRARIES}
   ${GPGME_LIBRARIES}
   ${LIBASSUAN_LIBRARIES})
-target_compile_definitions(${PROJECT_NAME} PRIVATE
-  -DG_LOG_DOMAIN="CREATEREPO_AGENT")
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
   COMPONENT bin)

--- a/src/createrepo-agent/agent.c
+++ b/src/createrepo-agent/agent.c
@@ -18,8 +18,6 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/un.h>
 
 #include <createrepo_c/createrepo_c.h>
 #include <glib.h>
@@ -29,56 +27,7 @@
 #include "createrepo-agent/command.h"
 #include "createrepo-agent/common.h"
 #include "createrepo-agent/options.h"
-
-static gpg_error_t
-try_server(const char * name)
-{
-  assuan_context_t ctx;
-  gpg_error_t rc;
-
-  rc = assuan_new(&ctx);
-  if (rc) {
-    return rc;
-  }
-
-  rc = assuan_socket_connect(ctx, name, ASSUAN_INVALID_PID, 0);
-
-  assuan_release(ctx);
-
-  return rc;
-}
-
-static assuan_fd_t
-create_server_socket(const char * name)
-{
-  struct sockaddr_un addr_un;
-  struct sockaddr * addr = (struct sockaddr *)&addr_un;
-  assuan_fd_t fd;
-  int r_redirected;
-
-  addr_un.sun_family = AF_UNIX;
-
-  if (assuan_sock_set_sockaddr_un(name, addr, &r_redirected)) {
-    return ASSUAN_INVALID_FD;
-  }
-
-  fd = assuan_sock_new(addr_un.sun_family, SOCK_STREAM, 0);
-  if (fd == ASSUAN_INVALID_FD) {
-    return ASSUAN_INVALID_FD;
-  }
-
-  if (assuan_sock_bind(fd, addr, sizeof(addr_un))) {
-    assuan_sock_close(fd);
-    return ASSUAN_INVALID_FD;
-  }
-
-  if (listen(fd, SOMAXCONN)) {
-    assuan_sock_close(fd);
-    return ASSUAN_INVALID_FD;
-  }
-
-  return fd;
-}
+#include "createrepo-agent/server.h"
 
 void
 ignore_sigpipe()

--- a/src/createrepo-agent/server.c
+++ b/src/createrepo-agent/server.c
@@ -1,0 +1,70 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <assuan.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "createrepo-agent/command.h"
+#include "createrepo-agent/server.h"
+
+gpg_error_t
+try_server(const char * name)
+{
+  assuan_context_t ctx;
+  gpg_error_t rc;
+
+  rc = assuan_new(&ctx);
+  if (rc) {
+    return rc;
+  }
+
+  rc = assuan_socket_connect(ctx, name, ASSUAN_INVALID_PID, 0);
+
+  assuan_release(ctx);
+
+  return rc;
+}
+
+assuan_fd_t
+create_server_socket(const char * name)
+{
+  struct sockaddr_un addr_un;
+  struct sockaddr * addr = (struct sockaddr *)&addr_un;
+  assuan_fd_t fd;
+  int r_redirected;
+
+  addr_un.sun_family = AF_UNIX;
+
+  if (assuan_sock_set_sockaddr_un(name, addr, &r_redirected)) {
+    return ASSUAN_INVALID_FD;
+  }
+
+  fd = assuan_sock_new(addr_un.sun_family, SOCK_STREAM, 0);
+  if (fd == ASSUAN_INVALID_FD) {
+    return ASSUAN_INVALID_FD;
+  }
+
+  if (assuan_sock_bind(fd, addr, sizeof(addr_un))) {
+    assuan_sock_close(fd);
+    return ASSUAN_INVALID_FD;
+  }
+
+  if (listen(fd, SOMAXCONN)) {
+    assuan_sock_close(fd);
+    return ASSUAN_INVALID_FD;
+  }
+
+  return fd;
+}

--- a/src/createrepo-agent/server.h
+++ b/src/createrepo-agent/server.h
@@ -1,0 +1,35 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CREATEREPO_AGENT__SERVER_H_
+#define CREATEREPO_AGENT__SERVER_H_
+
+#include <assuan.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+gpg_error_t
+try_server(const char * name);
+
+assuan_fd_t
+create_server_socket(const char * name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CREATEREPO_AGENT__SERVER_H_


### PR DESCRIPTION
Two facets to this change:
* Move some server-specific startup code out of agent.c into a separate file so that it can be used in tests.
* Compile most of the server and client code as a CMake 'object' library so that it can be used in tests.