### PR TITLE
Make tests compatible with older GTest and GCC

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(GTest REQUIRED)
 macro(add_cache_test NAME)
   add_executable(test_${NAME} "main.cpp" "test_${NAME}.cpp")
   target_link_libraries(test_${NAME}
+    "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>"
     ${GTEST_LIBRARIES}
     createrepo-cache)
   add_test(NAME ${NAME} COMMAND test_${NAME})
@@ -18,6 +19,7 @@ endmacro()
 macro(add_integration_test NAME)
   add_executable(test_${NAME} "integration_main.cpp" "test_${NAME}.cpp")
   target_link_libraries(test_${NAME}
+    "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>"
     ${GTEST_LIBRARIES}
     createrepo-agent-lib)
   add_test(NAME ${NAME} COMMAND test_${NAME})

--- a/test/test_smoke.cpp
+++ b/test/test_smoke.cpp
@@ -22,4 +22,4 @@ TEST_P(smoke, commit) {
   gpg_error_t rc = assuan_transact(client, "COMMIT", NULL, NULL, NULL, NULL, NULL, NULL);
   EXPECT_FALSE(rc);
 }
-INSTANTIATE_TEST_SUITE_P( , smoke, testing::Values("empty", "populated"), smoke::PrintParamName);
+INSTANTIATE_TEST_CASE_P(smoke, smoke, testing::Values("empty", "populated"), smoke::PrintParamName);


### PR DESCRIPTION
In particular, this allows the tests to build on RHEL 8 where we have GCC 8.5 and GTest 1.8.0.

It looks like `INSTANTIATE_TEST_CASE_P` is the older, deprecated nomenclature, and we should consider switching to the modern nomenclature once we no longer need to support RHEL 8.