### PR TITLE
Add "touch" operation

### DIFF
--- a/src/createrepo-agent/command.c
+++ b/src/createrepo-agent/command.c
@@ -680,6 +680,52 @@ cmd_sync_pattern(assuan_context_t ctx, char * line)
   return cmd_ok(ctx);
 }
 
+#define HLP_TOUCH \
+  "TOUCH [ARCH ...]\n\nForce write of metadata even if there are no changes"
+gpg_error_t
+cmd_touch(assuan_context_t ctx, char * line)
+{
+  struct command_context * cmd_ctx;
+  char * arch;
+  int rc;
+
+  cmd_ctx = (struct command_context *)assuan_get_pointer(ctx);
+  if (!cmd_ctx) {
+    return cmd_error(ctx, GPG_ERR_ASSUAN_SERVER_FAULT, NULL);
+  }
+
+  if (!*line) {
+    rc = cra_stage_touch(cmd_ctx->stage, NULL);
+    if (rc) {
+      return cmd_error(ctx, GPG_ERR_GENERAL, cr_strerror(rc));
+    }
+
+    return cmd_ok(ctx);
+  }
+
+  while (*line) {
+    arch = line;
+    while (*line && *line != ' ' && *line != '\t') {
+      line++;
+    }
+    if (*line) {
+      *line = '\0';
+      line++;
+    }
+
+    rc = cra_stage_touch(cmd_ctx->stage, arch);
+    if (rc) {
+      return cmd_error(ctx, GPG_ERR_GENERAL, cr_strerror(rc));
+    }
+
+    while (*line == ' ' || *line == '\t') {
+      line++;
+    }
+  }
+
+  return cmd_ok(ctx);
+}
+
 static const struct
 {
   const char * const name;
@@ -693,6 +739,7 @@ static const struct
   {"SHUTDOWN", cmd_shutdown, HLP_SHUTDOWN},
   {"SYNC", cmd_sync, HLP_SYNC},
   {"SYNC_PATTERN", cmd_sync_pattern, HLP_SYNC_PATTERN},
+  {"TOUCH", cmd_touch, HLP_TOUCH},
   {NULL},
 };
 

--- a/src/createrepo-cache/coordinator.c
+++ b/src/createrepo-cache/coordinator.c
@@ -178,6 +178,10 @@ cra_coordinator_commit(cra_Coordinator * coordinator)
         }
       }
 
+      if (!rc && op->touch) {
+        rc = cra_cache_touch(coordinator->cache, op->arch_name);
+      }
+
       cra_stage_operation_free(op);
     }
 
@@ -382,6 +386,23 @@ cra_stage_pattern_remove(
   op->remove_family = family;
   op->remove_dependants = dependants;
   op->remove_missing_ok = missing_ok;
+
+  g_queue_push_tail(stage->operations, op);
+
+  return CRE_OK;
+}
+
+int
+cra_stage_touch(cra_Stage * stage, const char * arch_name)
+{
+  cra_StageOperation * op;
+
+  op = cra_stage_operation_new(arch_name);
+  if (!op) {
+    return CRE_MEMORY;
+  }
+
+  op->touch = TRUE;
 
   g_queue_push_tail(stage->operations, op);
 

--- a/src/createrepo-cache/coordinator.h
+++ b/src/createrepo-cache/coordinator.h
@@ -58,6 +58,9 @@ cra_stage_pattern_remove(
   cra_Stage * stage, const char * arch_name, GRegex * pattern,
   gboolean family, gboolean dependants, gboolean missing_ok);
 
+int
+cra_stage_touch(cra_Stage * stage, const char * arch_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/createrepo-cache/coordinator_priv.h
+++ b/src/createrepo-cache/coordinator_priv.h
@@ -36,6 +36,7 @@ typedef struct
   gboolean remove_family;
   gboolean remove_dependants;
   gboolean remove_missing_ok;
+  gboolean touch;
 } cra_StageOperation;
 
 struct _cra_Coordinator

--- a/src/createrepo-cache/repo_cache.c
+++ b/src/createrepo-cache/repo_cache.c
@@ -1997,6 +1997,26 @@ cra_sign_repomd(
 }
 
 int
+cra_cache_touch(cra_Cache * cache, const char * arch_name)
+{
+  cra_ArchCache * arch = NULL;
+
+  if (!arch_name) {
+    cache->source_repo->flags |= CRA_REPO_DIRTY;
+  } else {
+    arch = g_hash_table_lookup(cache->arches, arch_name);
+    if (!arch) {
+      return CRE_BADARG;
+    }
+    arch->arch_repo->flags |= CRA_REPO_DIRTY;
+    arch->debug_repo->flags |= CRA_REPO_DIRTY;
+    cache->source_repo->flags |= CRA_REPO_DIRTY;
+  }
+
+  return CRE_OK;
+}
+
+int
 cra_cache_flush(cra_Cache * cache)
 {
   int rc;

--- a/src/createrepo-cache/repo_cache.h
+++ b/src/createrepo-cache/repo_cache.h
@@ -70,6 +70,9 @@ cra_cache_pattern_remove(
   gboolean family, gboolean dependants);
 
 int
+cra_cache_touch(cra_Cache * cache, const char * arch_name);
+
+int
 cra_cache_flush(cra_Cache * cache);
 
 cra_CacheStats

--- a/src/python/client.c
+++ b/src/python/client.c
@@ -329,6 +329,36 @@ client_sync(ClientObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
+client_touch(ClientObject *self, PyObject *args)
+{
+  PyObject *arches = NULL;
+  gchar *arch_list = NULL;
+  gchar *cmd;
+  PyObject *ret;
+
+  if (!PyArg_ParseTuple(args, "|O", &arches)) {
+    return NULL;
+  }
+
+  if (arches != NULL && arches != Py_None) {
+    arch_list = parse_arch_list(arches);
+    if (NULL == arch_list) {
+      return NULL;
+    }
+  }
+
+  cmd = g_strjoin(" ", "TOUCH", arch_list, NULL);
+  g_free(arch_list);
+  if (!cmd) {
+    return PyErr_NoMemory();
+  }
+
+  ret = execute_transaction(self, cmd);
+  g_free(cmd);
+  return ret;
+}
+
+static PyObject *
 client_enter(ClientObject *self, PyObject *args)
 {
   (void)args;
@@ -360,6 +390,7 @@ static struct PyMethodDef client_methods[] = {
   {"set_invalidate_dependants", (PyCFunction)client_set_invalidate_dependants, METH_VARARGS, NULL},
   {"set_invalidate_family", (PyCFunction)client_set_invalidate_family, METH_VARARGS, NULL},
   {"sync", (PyCFunction)(void(*)(void))client_sync, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"touch", (PyCFunction)client_touch, METH_VARARGS, NULL},
   {"__enter__", (PyCFunction)client_enter, METH_NOARGS, NULL},
   {"__exit__", (PyCFunction)client_disconnect, METH_VARARGS, NULL},
   {NULL, NULL, 0, NULL}

--- a/test/test_smoke.cpp
+++ b/test/test_smoke.cpp
@@ -26,8 +26,10 @@ TEST_P(smoke, commit) {
 }
 
 TEST_P(smoke, touch) {
+  // Include extra whitespace around command arguments
+  // to check that it's accepted.
   gpg_error_t rc = assuan_transact(
-    client, "TOUCH aarch64 x86_64", NULL, NULL, NULL, NULL, NULL, NULL);
+    client, "TOUCH \t aarch64 \t x86_64 ", NULL, NULL, NULL, NULL, NULL, NULL);
   EXPECT_FALSE(rc);
   rc = assuan_transact(client, "COMMIT", NULL, NULL, NULL, NULL, NULL, NULL);
   EXPECT_FALSE(rc);

--- a/test/test_smoke.cpp
+++ b/test/test_smoke.cpp
@@ -16,10 +16,38 @@
 
 #include "integration_utils.hpp"
 
+namespace fs = std::filesystem;
+
 class smoke : public CRATempServer {};
 
 TEST_P(smoke, commit) {
   gpg_error_t rc = assuan_transact(client, "COMMIT", NULL, NULL, NULL, NULL, NULL, NULL);
   EXPECT_FALSE(rc);
 }
-INSTANTIATE_TEST_CASE_P(smoke, smoke, testing::Values("empty", "populated"), smoke::PrintParamName);
+
+TEST_P(smoke, touch) {
+  gpg_error_t rc = assuan_transact(
+    client, "TOUCH aarch64 x86_64", NULL, NULL, NULL, NULL, NULL, NULL);
+  EXPECT_FALSE(rc);
+  rc = assuan_transact(client, "COMMIT", NULL, NULL, NULL, NULL, NULL, NULL);
+  EXPECT_FALSE(rc);
+
+  fs::path srpm_path = temp_dir / "SRPMS";
+  fs::path repomd_path = srpm_path / "repodata" / "repomd.xml";
+
+  EXPECT_TRUE(fs::exists(repomd_path));
+
+  for (const auto & arch : {"aarch64", "x86_64"}) {
+    fs::path arch_path = temp_dir / arch;
+    repomd_path = arch_path / "repodata" / "repomd.xml";
+
+    EXPECT_TRUE(fs::exists(repomd_path));
+
+    repomd_path = arch_path / "debug" / "repodata" / "repomd.xml";
+
+    EXPECT_TRUE(fs::exists(repomd_path));
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+  smoke, smoke, testing::Values("bare", "empty", "populated"), smoke::PrintParamName);

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -133,12 +133,21 @@ def test_sync_pattern_miss(tmp_path):
     assert not (arch_path / 'Packages' / 'r' / POPULATED_RPM.name).is_file()
 
 
-def test_touch(tmp_path):
-    arches = ('aarch64', 'x86_64')
-
+@pytest.mark.parametrize('arches', (
+    (('x86_64', )),
+    (('aarch64', 'x86_64')),
+))
+def test_touch(tmp_path, arches):
     with createrepo_agent.Server(str(tmp_path)):
         with createrepo_agent.Client(str(tmp_path)) as c:
+            with pytest.raises(TypeError):
+                c.touch(1)
+            with pytest.raises(TypeError):
+                c.touch((1,))
+            with pytest.raises(TypeError):
+                c.touch(arches, 1)
             c.touch()
+            c.touch(None)
             c.touch(arches)
             c.commit()
 

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -131,3 +131,28 @@ def test_sync_pattern_miss(tmp_path):
     arch_path = tmp_path / 'x86_64'
 
     assert not (arch_path / 'Packages' / 'r' / POPULATED_RPM.name).is_file()
+
+
+def test_touch(tmp_path):
+    arches = ('aarch64', 'x86_64')
+
+    with createrepo_agent.Server(str(tmp_path)):
+        with createrepo_agent.Client(str(tmp_path)) as c:
+            c.touch()
+            c.touch(arches)
+            c.commit()
+
+    srpm_path = tmp_path / 'SRPMS'
+    repomd_path = srpm_path / 'repodata' / 'repomd.xml'
+
+    assert repomd_path.is_file()
+
+    for arch in arches:
+        arch_path = tmp_path / arch
+        repomd_path = arch_path / 'repodata' / 'repomd.xml'
+
+        assert repomd_path.is_file()
+
+        repomd_path = arch_path / 'debug' / 'repodata' / 'repomd.xml'
+
+        assert repomd_path.is_file()

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -292,3 +292,26 @@ def test_touch(tmp_path, arches):
         repomd_path = arch_path / 'debug' / 'repodata' / 'repomd.xml'
 
         assert repomd_path.is_file()
+
+
+def test_touch_forces_rewrite(mutable_populated_repo: Path) -> None:
+    arch_path = mutable_populated_repo / 'x86_64'
+    repomd_path = arch_path / 'repodata' / 'repomd.xml'
+
+    assert repomd_path.is_file()
+    old_repomd_contents = repomd_path.read_text()
+
+    # A plain commit with nothing staged must not rewrite already-clean metadata.
+    with createrepo_agent.Server(str(mutable_populated_repo)):
+        with createrepo_agent.Client(str(mutable_populated_repo)) as c:
+            c.commit()
+
+    assert old_repomd_contents == repomd_path.read_text()
+
+    # 'touch' must force a metadata rewrite even though nothing else changed.
+    with createrepo_agent.Server(str(mutable_populated_repo)):
+        with createrepo_agent.Client(str(mutable_populated_repo)) as c:
+            c.touch(('x86_64',))
+            c.commit()
+
+    assert old_repomd_contents != repomd_path.read_text()


### PR DESCRIPTION
This operation is intended to function similar to the "touch" command and will essentially bypass the optimizations which avoid modifying repository metadata when there are no effective changes to it.

It is particularly useful for using createrepo-agent to generate initial metadata for an empty repository without seeding it with any packages.

The actual effect of this change happens in `repo_cache.c`. All the rest of the changes are plumbing and tests.