### PR TITLE
Add remove_{name,pattern} operations to Python client

### DIFF
--- a/src/python/client.c
+++ b/src/python/client.c
@@ -241,6 +241,68 @@ client_disconnect(ClientObject *self, PyObject *args)
 }
 
 static PyObject *
+client_remove_name(ClientObject *self, PyObject *args)
+{
+  char *name = NULL;
+  PyObject *arches = NULL;
+  gchar *arch_list = NULL;
+  gchar *cmd;
+  PyObject *ret;
+
+  if (!PyArg_ParseTuple(args, "s|O", &name, &arches)) {
+    return NULL;
+  }
+
+  if (arches != NULL && arches != Py_None) {
+    arch_list = parse_arch_list(arches);
+    if (NULL == arch_list) {
+      return NULL;
+    }
+  }
+
+  cmd = g_strjoin(" ", "REMOVE_NAME", name, arch_list, NULL);
+  g_free(arch_list);
+  if (!cmd) {
+    return PyErr_NoMemory();
+  }
+
+  ret = execute_transaction(self, cmd);
+  g_free(cmd);
+  return ret;
+}
+
+static PyObject *
+client_remove_pattern(ClientObject *self, PyObject *args)
+{
+  char *pattern = NULL;
+  PyObject *arches = NULL;
+  gchar *arch_list = NULL;
+  gchar *cmd;
+  PyObject *ret;
+
+  if (!PyArg_ParseTuple(args, "s|O", &pattern, &arches)) {
+    return NULL;
+  }
+
+  if (arches != NULL && arches != Py_None) {
+    arch_list = parse_arch_list(arches);
+    if (NULL == arch_list) {
+      return NULL;
+    }
+  }
+
+  cmd = g_strjoin(" ", "REMOVE_PATTERN", pattern, arch_list, NULL);
+  g_free(arch_list);
+  if (!cmd) {
+    return PyErr_NoMemory();
+  }
+
+  ret = execute_transaction(self, cmd);
+  g_free(cmd);
+  return ret;
+}
+
+static PyObject *
 set_option(ClientObject *self, const char * option_name, int value)
 {
   gchar * cmd;
@@ -283,6 +345,18 @@ client_set_invalidate_family(ClientObject *self, PyObject *args)
   }
 
   return set_option(self, "invalidate_family", invalidate_family);
+}
+
+static PyObject *
+client_set_missing_ok(ClientObject *self, PyObject *args)
+{
+  int missing_ok;
+
+  if (!PyArg_ParseTuple(args, "p", &missing_ok)) {
+    return NULL;
+  }
+
+  return set_option(self, "missing_ok", missing_ok);
 }
 
 static PyObject *
@@ -357,8 +431,11 @@ static struct PyMethodDef client_methods[] = {
   {"commit", (PyCFunction)client_commit, METH_NOARGS, NULL},
   {"connect", (PyCFunction)client_connect, METH_NOARGS, NULL},
   {"disconnect", (PyCFunction)client_disconnect, METH_NOARGS, NULL},
+  {"remove_name", (PyCFunction)client_remove_name, METH_VARARGS, NULL},
+  {"remove_pattern", (PyCFunction)client_remove_pattern, METH_VARARGS, NULL},
   {"set_invalidate_dependants", (PyCFunction)client_set_invalidate_dependants, METH_VARARGS, NULL},
   {"set_invalidate_family", (PyCFunction)client_set_invalidate_family, METH_VARARGS, NULL},
+  {"set_missing_ok", (PyCFunction)client_set_missing_ok, METH_VARARGS, NULL},
   {"sync", (PyCFunction)(void(*)(void))client_sync, METH_VARARGS | METH_KEYWORDS, NULL},
   {"__enter__", (PyCFunction)client_enter, METH_NOARGS, NULL},
   {"__exit__", (PyCFunction)client_disconnect, METH_VARARGS, NULL},

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -235,3 +235,25 @@ def test_remove_pattern(mutable_populated_repo):
         arch_path = mutable_populated_repo / arch
         pkg_path = arch_path / 'Packages' / 'r' / POPULATED_RPM.name
         assert not pkg_path.is_file()
+
+
+@pytest.mark.parametrize('option_name', (
+    'invalidate_dependants',
+    'invalidate_family',
+    'missing_ok',
+))
+def test_option_arguments(tmp_path, option_name):
+    with createrepo_agent.Server(str(tmp_path)):
+        with createrepo_agent.Client(str(tmp_path)) as c:
+            setter = getattr(c, f'set_{option_name}')
+
+            setter(True)
+            setter(False)
+
+            # Must provide value
+            with pytest.raises(TypeError):
+                setter()
+
+            # Only one argument accepted
+            with pytest.raises(TypeError):
+                setter(True, None)

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -154,6 +154,16 @@ def test_remove_name(mutable_populated_repo):
             with pytest.raises(TypeError):
                 c.remove_name('ros-dev-tools', arches, 1)
 
+            # Omitting arches targets SRPMS which has no such package
+            c.remove_name('ros-dev-tools')
+            with pytest.raises(RuntimeError):
+                c.commit()
+
+            # Function treats 'None' arches the same as omission
+            c.remove_name('ros-dev-tools', None)
+            with pytest.raises(RuntimeError):
+                c.commit()
+
             # Remove package
             c.remove_name('ros-dev-tools', arches)
             c.commit()
@@ -167,6 +177,12 @@ def test_remove_name(mutable_populated_repo):
             c.set_missing_ok(True)
             c.remove_name('ros-dev-tools', arches)
             c.commit()
+
+            # ...and explicitly disallow
+            c.set_missing_ok(False)
+            c.remove_name('ros-dev-tools', arches)
+            with pytest.raises(RuntimeError):
+                c.commit()
 
     for arch in arches:
         arch_path = mutable_populated_repo / arch
@@ -185,6 +201,16 @@ def test_remove_pattern(mutable_populated_repo):
             with pytest.raises(TypeError):
                 c.remove_pattern('ros-.*', arches, 1)
 
+            # Omitting arches targets SRPMS which has no such package
+            c.remove_pattern('ros-.*')
+            with pytest.raises(RuntimeError):
+                c.commit()
+
+            # Function treats 'None' arches the same as omission
+            c.remove_pattern('ros-.*', None)
+            with pytest.raises(RuntimeError):
+                c.commit()
+
             # Remove package
             c.remove_pattern('ros-.*', arches)
             c.commit()
@@ -198,6 +224,12 @@ def test_remove_pattern(mutable_populated_repo):
             c.set_missing_ok(True)
             c.remove_pattern('ros-.*', arches)
             c.commit()
+
+            # ...and explicitly disallow
+            c.set_missing_ok(False)
+            c.remove_pattern('ros-.*', arches)
+            with pytest.raises(RuntimeError):
+                c.commit()
 
     for arch in arches:
         arch_path = mutable_populated_repo / arch

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 from pathlib import Path
+import shutil
 
 import createrepo_agent
 import pytest
@@ -16,6 +17,15 @@ POPULATED_RPM = Path(
     'r',
     'ros-dev-tools-1.0.1-1.el9.noarch.rpm',
 )
+
+
+@pytest.fixture
+def mutable_populated_repo(tmp_path):
+    repo_path = tmp_path / 'populated'
+    shutil.copytree(
+        str(POPULATED_REPO), str(repo_path),
+        ignore=shutil.ignore_patterns('repomd.xml.asc'))
+    yield repo_path
 
 
 def test_version():
@@ -131,3 +141,65 @@ def test_sync_pattern_miss(tmp_path):
     arch_path = tmp_path / 'x86_64'
 
     assert not (arch_path / 'Packages' / 'r' / POPULATED_RPM.name).is_file()
+
+
+def test_remove_name(mutable_populated_repo):
+    arches = ('x86_64', )
+    with createrepo_agent.Server(str(mutable_populated_repo)):
+        with createrepo_agent.Client(str(mutable_populated_repo)) as c:
+            with pytest.raises(TypeError):
+                c.remove_name(1)
+            with pytest.raises(TypeError):
+                c.remove_name('ros-dev-tools', (1,))
+            with pytest.raises(TypeError):
+                c.remove_name('ros-dev-tools', arches, 1)
+
+            # Remove package
+            c.remove_name('ros-dev-tools', arches)
+            c.commit()
+
+            # Try to remove again - expected to fail
+            c.remove_name('ros-dev-tools', arches)
+            with pytest.raises(RuntimeError):
+                c.commit()
+
+            # Explicitly allow no matches
+            c.set_missing_ok(True)
+            c.remove_name('ros-dev-tools', arches)
+            c.commit()
+
+    for arch in arches:
+        arch_path = mutable_populated_repo / arch
+        pkg_path = arch_path / 'Packages' / 'r' / POPULATED_RPM.name
+        assert not pkg_path.is_file()
+
+
+def test_remove_pattern(mutable_populated_repo):
+    arches = ('x86_64', )
+    with createrepo_agent.Server(str(mutable_populated_repo)):
+        with createrepo_agent.Client(str(mutable_populated_repo)) as c:
+            with pytest.raises(TypeError):
+                c.remove_pattern(1)
+            with pytest.raises(TypeError):
+                c.remove_pattern('ros-.*', (1,))
+            with pytest.raises(TypeError):
+                c.remove_pattern('ros-.*', arches, 1)
+
+            # Remove package
+            c.remove_pattern('ros-.*', arches)
+            c.commit()
+
+            # Try to remove again - expected to fail
+            c.remove_pattern('ros-.*', arches)
+            with pytest.raises(RuntimeError):
+                c.commit()
+
+            # Explicitly allow no matches
+            c.set_missing_ok(True)
+            c.remove_pattern('ros-.*', arches)
+            c.commit()
+
+    for arch in arches:
+        arch_path = mutable_populated_repo / arch
+        pkg_path = arch_path / 'Packages' / 'r' / POPULATED_RPM.name
+        assert not pkg_path.is_file()


### PR DESCRIPTION
Both of these operations take a string, so I don't see a good way to combine them like I did for the `add` operation.

Additionally, the `missing_ok` option is related to the `remove_*` operations, so I added that as well.

Note that all of these operations were already supported by createrepo-agent, this change just adds support for invoking them from the Python extension.