### PR TITLE
Allow inheritance from Python classes

### DIFF
--- a/src/python/client.c
+++ b/src/python/client.c
@@ -378,6 +378,7 @@ PyTypeObject Client_Type = {
   .tp_dealloc = (destructor)client_dealloc,
   .tp_init = (initproc)client_init,
   .tp_repr = (reprfunc)client_repr,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_methods = client_methods,
   .tp_getset = client_properties,
 };

--- a/src/python/server.c
+++ b/src/python/server.c
@@ -223,6 +223,7 @@ PyTypeObject Server_Type = {
   .tp_dealloc = (destructor)server_dealloc,
   .tp_init = (initproc)server_init,
   .tp_repr = (reprfunc)server_repr,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_methods = server_methods,
   .tp_getset = server_properties,
 };


### PR DESCRIPTION
Evidently we need to explicitly add a flag to allow inheritance from our Python classes. I don't see any reason we wouldn't want to allow that.

https://docs.python.org/3/c-api/typeobj.html#c.Py_TPFLAGS_BASETYPE