### PR TITLE
Add compatibility helper for older Pytest versions

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from pathlib import Path
+
+import pytest
+
+
+if getattr(pytest, 'version_tuple', ()) < (3, 9):
+    @pytest.fixture
+    def tmp_path(tmpdir):
+        """
+        Compatibility fixture for temporary directory allocation.
+
+        This can be removed when we drop support for platforms with Pytest
+        versions older than 3.9 (namely Enterprise Linux 8).
+        """
+        return Path(tmpdir)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,12 +1,16 @@
 # Copyright 2026 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+from itertools import takewhile
 from pathlib import Path
 
 import pytest
 
+pytest_version = tuple(
+    int(x) for x in takewhile(str.isdigit, pytest.__version__.split('.'))
+)
 
-if getattr(pytest, 'version_tuple', ()) < (3, 9):
+if pytest_version < (3, 9):
     @pytest.fixture
     def tmp_path(tmpdir):
         """


### PR DESCRIPTION
The `tmp_path` fixture was introduced in Pytest 3.9. Include an explicit definition of that fixture for compatibility with those older Pytest versions. When we're ready to drop support, we can just remove the fixture.

We could test this in GitHub Actions but it would be pretty contrived. I think it would be OK to carry this as a compatibility extension without explicitly testing it in CI, but I'm open to hearing differing opinions.