### PR TITLE
Close a small memory leak when stage initialization fails

### DIFF
--- a/src/createrepo-agent/command.c
+++ b/src/createrepo-agent/command.c
@@ -846,6 +846,7 @@ command_handler(int fd, const char * path, volatile sig_atomic_t * sentinel)
     cmd_ctx->stage = cra_stage_new(coordinator);
     if (!cmd_ctx->stage) {
       fprintf(stderr, "stage init failed\n");
+      free(cmd_ctx);
       client_worker_free(ctx);
       break;
     }


### PR DESCRIPTION
Ownership of `cmd_ctx` doesn't get transferred to `ctx` until 5 lines later, so we need to explicitly free it during failure handling here.